### PR TITLE
条件一覧のblankメッセージ表示と検索フォームのバリデータ実装

### DIFF
--- a/src/app/mypage/condition-list/condition-list.component.html
+++ b/src/app/mypage/condition-list/condition-list.component.html
@@ -1,7 +1,7 @@
 <div class="condition-list">
   <div
     class="condition-list__list"
-    *ngIf="conditionList; else blank"
+    *ngIf="conditionList.length > 0; else blank"
     infiniteScroll
     [infiniteScrollDistance]="2"
     [infiniteScrollThrottle]="50"
@@ -21,7 +21,7 @@
   </div>
   <ng-template #blank>
     <p class="condition-list__none" *ngIf="!loading">
-      保存された条件はありません。
+      {{ blankMessage }}
     </p>
   </ng-template>
 </div>

--- a/src/app/mypage/condition-list/condition-list.component.ts
+++ b/src/app/mypage/condition-list/condition-list.component.ts
@@ -12,6 +12,7 @@ export class ConditionListComponent implements OnInit {
   @Input() conditionList: Condition[];
   @Input() loading: boolean;
   @Input() rate: Insurance;
+  @Input() blankMessage: string;
 
   @Output() scrolled = new EventEmitter();
 

--- a/src/app/mypage/result-main/result-main.component.html
+++ b/src/app/mypage/result-main/result-main.component.html
@@ -3,5 +3,6 @@
   [rate]="rateService.rate"
   [conditionList]="conditionList"
   [loading]="loading"
+  blankMessage="保存された条件はありません。"
   (scrolled)="getConditions()"
 ></app-condition-list>

--- a/src/app/mypage/result-main/result-main.component.ts
+++ b/src/app/mypage/result-main/result-main.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { QueryDocumentSnapshot } from '@angular/fire/firestore';
 import { take } from 'rxjs/operators';
 import { Condition } from 'src/app/interfaces/condition';
 import { AuthService } from 'src/app/services/auth.service';
@@ -14,8 +15,8 @@ export class ResultMainComponent implements OnInit {
   conditionList: Condition[] = [];
   loading: boolean;
 
-  isComplete: boolean;
-  lastCondition;
+  private isComplete: boolean;
+  private lastCondition: QueryDocumentSnapshot<Condition>;
 
   constructor(
     public rateService: RateService,
@@ -36,17 +37,14 @@ export class ResultMainComponent implements OnInit {
       .getConditions(this.authService.uid, this.lastCondition)
       .pipe(take(1))
       .subscribe((docs) => {
-        if (docs) {
-          if (docs.length) {
-            this.lastCondition = docs[docs.length - 1];
-            const conditions = docs.map((doc) => doc.data());
-            this.conditionList.push(...conditions);
-            this.loading = false;
-          } else {
-            this.isComplete = true;
-            this.loading = false;
-          }
+        if (docs?.length) {
+          this.lastCondition = docs[docs.length - 1];
+          const conditions = docs.map((doc) => doc.data());
+          this.conditionList.push(...conditions);
+        } else {
+          this.isComplete = true;
         }
+        this.loading = false;
       });
   }
 }

--- a/src/app/mypage/result-search/result-search.component.html
+++ b/src/app/mypage/result-search/result-search.component.html
@@ -3,5 +3,6 @@
   [rate]="rateService.rate"
   [conditionList]="conditionList"
   [loading]="loading"
+  blankMessage="該当する条件はありません。"
   (scrolled)="addSearch()"
 ></app-condition-list>

--- a/src/app/mypage/result-search/result-search.component.ts
+++ b/src/app/mypage/result-search/result-search.component.ts
@@ -14,25 +14,22 @@ export class ResultSearchComponent implements OnInit {
   conditionList: Condition[];
   loading: boolean;
 
-  queryTitle: string;
-  typeFilter: string;
-  baseLower: number;
-  baseUpper: number;
-  allowanceLower: number;
-  allowanceUpper: number;
-  basePerHourLower: number;
-  basePerHourUpper: number;
-  baseRange: string;
-  page: number;
-  perPage = 18;
-  maxPage: number;
-  isInit = true;
-
+  private queryTitle: string;
+  private typeFilter: string;
+  private baseLower: number;
+  private baseUpper: number;
+  private allowanceLower: number;
+  private allowanceUpper: number;
+  private basePerHourLower: number;
+  private basePerHourUpper: number;
+  private readonly perPage = 18;
+  private page: number;
+  private maxPage: number;
   private index = this.searchService.index.condition;
 
   constructor(
     public rateService: RateService,
-    public searchService: SearchService,
+    private searchService: SearchService,
     private authService: AuthService,
     private route: ActivatedRoute
   ) {}
@@ -41,7 +38,12 @@ export class ResultSearchComponent implements OnInit {
     this.initialSearch();
   }
 
-  pushRange(rangeList: string[], key: string, lower?: number, upper?: number) {
+  private pushRange(
+    rangeList: string[],
+    key: string,
+    lower?: number,
+    upper?: number
+  ) {
     if (lower && upper) {
       rangeList.push(`${key}: ${lower} TO ${upper}`);
     } else if (lower) {
@@ -51,7 +53,7 @@ export class ResultSearchComponent implements OnInit {
     }
   }
 
-  setRange() {
+  private setRange() {
     const rangeList: string[] = [];
 
     this.pushRange(rangeList, 'base', this.baseLower, this.baseUpper);
@@ -71,7 +73,7 @@ export class ResultSearchComponent implements OnInit {
     return rangeList;
   }
 
-  search() {
+  private search() {
     if (!this.loading) {
       this.loading = true;
       this.index
@@ -107,7 +109,6 @@ export class ResultSearchComponent implements OnInit {
       this.basePerHourLower = +params.get('basePerHourLower');
       this.basePerHourUpper = +params.get('basePerHourUpper');
       this.search();
-      this.isInit = false;
     });
   }
 

--- a/src/app/mypage/search-form/search-form.component.html
+++ b/src/app/mypage/search-form/search-form.component.html
@@ -1,138 +1,136 @@
-<mat-expansion-panel>
-  <mat-expansion-panel-header>
-    <mat-panel-title>
-      絞り込み設定
-    </mat-panel-title>
-  </mat-expansion-panel-header>
+<mat-card>
+  <mat-card-header>絞り込み設定</mat-card-header>
   <form [formGroup]="form" class="form">
-    <dl class="form__data">
-      <dt class="form__dt">条件名</dt>
-      <dd class="form__dd">
-        <mat-form-field class="form__title">
-          <mat-label>条件名で探す</mat-label>
-          <input
-            type="text"
-            matInput
-            autocomplete="off"
-            formControlName="title"
-            [value]="form.value.title"
-          />
-        </mat-form-field>
-      </dd>
-    </dl>
-    <dl class="form__data">
-      <dt class="form__dt">基本給</dt>
-      <dd class="form__dd">
-        <mat-checkbox
-          class="form__radio-btn"
-          name="monthly"
-          formControlName="typeMonthly"
-          [value]="form.value.typeMonthly"
-          #typeMonthly
-          >月給</mat-checkbox
-        >
-        <mat-checkbox
-          class="form__radio-btn"
-          name="hourly"
-          formControlName="typeHourly"
-          [value]="form.value.typeHourly"
-          #typeHourly
-          >時給</mat-checkbox
-        >
-      </dd>
-    </dl>
-    <ng-container *ngIf="typeMonthly.checked">
+    <mat-card-content>
       <dl class="form__data">
-        <dt class="form__dt">月給</dt>
+        <dt class="form__dt">条件名</dt>
         <dd class="form__dd">
-          <mat-form-field class="form__field">
-            <mat-label>下限</mat-label>
+          <mat-form-field class="form__title">
+            <mat-label>条件名で探す</mat-label>
             <input
-              type="number"
+              type="text"
               matInput
               autocomplete="off"
-              formControlName="baseLower"
-              class="price"
+              formControlName="title"
+              [value]="form.value.title"
             />
           </mat-form-field>
-          〜
-          <mat-form-field class="form__field">
-            <mat-label>上限</mat-label>
-            <input
-              type="number"
-              matInput
-              autocomplete="off"
-              formControlName="baseUpper"
-              class="price"
-            />
-          </mat-form-field>
-          <span class="yen">円</span>
         </dd>
       </dl>
       <dl class="form__data">
-        <dt class="form__dt">諸手当</dt>
+        <dt class="form__dt">基本給</dt>
         <dd class="form__dd">
-          <mat-form-field class="form__field">
-            <mat-label>下限</mat-label>
-            <input
-              type="number"
-              matInput
-              autocomplete="off"
-              formControlName="allowanceLower"
-              class="price"
-            />
-          </mat-form-field>
-          〜
-          <mat-form-field class="form__field">
-            <mat-label>上限</mat-label>
-            <input
-              type="number"
-              matInput
-              autocomplete="off"
-              formControlName="allowanceUpper"
-              class="price"
-            />
-          </mat-form-field>
-          <span class="yen">円</span>
+          <mat-checkbox
+            class="form__radio-btn"
+            name="monthly"
+            formControlName="typeMonthly"
+            [value]="form.value.typeMonthly"
+            #typeMonthly
+            >月給</mat-checkbox
+          >
+          <mat-checkbox
+            class="form__radio-btn"
+            name="hourly"
+            formControlName="typeHourly"
+            [value]="form.value.typeHourly"
+            #typeHourly
+            >時給</mat-checkbox
+          >
         </dd>
       </dl>
-    </ng-container>
-    <ng-container *ngIf="typeHourly.checked">
-      <dl class="form__data">
-        <dt class="form__dt">時給</dt>
-        <dd class="form__dd">
-          <mat-form-field class="form__field">
-            <mat-label>下限</mat-label>
-            <input
-              type="number"
-              matInput
-              autocomplete="off"
-              formControlName="basePerHourLower"
-              class="price"
-            />
-          </mat-form-field>
-          〜
-          <mat-form-field class="form__field">
-            <mat-label>上限</mat-label>
-            <input
-              type="number"
-              matInput
-              autocomplete="off"
-              formControlName="basePerHourUpper"
-              class="price"
-            />
-          </mat-form-field>
-          <span class="yen">円</span>
-        </dd>
-      </dl>
-    </ng-container>
-    <div class="form__actions">
+      <ng-container *ngIf="typeMonthly.checked">
+        <dl class="form__data">
+          <dt class="form__dt">月給</dt>
+          <dd class="form__dd">
+            <mat-form-field class="form__field">
+              <mat-label>下限</mat-label>
+              <input
+                type="number"
+                matInput
+                autocomplete="off"
+                formControlName="baseLower"
+                class="price"
+              />
+            </mat-form-field>
+            〜
+            <mat-form-field class="form__field">
+              <mat-label>上限</mat-label>
+              <input
+                type="number"
+                matInput
+                autocomplete="off"
+                formControlName="baseUpper"
+                class="price"
+              />
+            </mat-form-field>
+            <span class="yen">円</span>
+          </dd>
+        </dl>
+        <dl class="form__data">
+          <dt class="form__dt">諸手当</dt>
+          <dd class="form__dd">
+            <mat-form-field class="form__field">
+              <mat-label>下限</mat-label>
+              <input
+                type="number"
+                matInput
+                autocomplete="off"
+                formControlName="allowanceLower"
+                class="price"
+              />
+            </mat-form-field>
+            〜
+            <mat-form-field class="form__field">
+              <mat-label>上限</mat-label>
+              <input
+                type="number"
+                matInput
+                autocomplete="off"
+                formControlName="allowanceUpper"
+                class="price"
+              />
+            </mat-form-field>
+            <span class="yen">円</span>
+          </dd>
+        </dl>
+      </ng-container>
+      <ng-container *ngIf="typeHourly.checked">
+        <dl class="form__data">
+          <dt class="form__dt">時給</dt>
+          <dd class="form__dd">
+            <mat-form-field class="form__field">
+              <mat-label>下限</mat-label>
+              <input
+                type="number"
+                matInput
+                autocomplete="off"
+                formControlName="basePerHourLower"
+                class="price"
+              />
+            </mat-form-field>
+            〜
+            <mat-form-field class="form__field">
+              <mat-label>上限</mat-label>
+              <input
+                type="number"
+                matInput
+                autocomplete="off"
+                formControlName="basePerHourUpper"
+                class="price"
+              />
+            </mat-form-field>
+            <span class="yen">円</span>
+          </dd>
+        </dl>
+      </ng-container>
+    </mat-card-content>
+    <mat-card-actions>
       <button mat-flat-button color="accent" (click)="serchConditions()">
         検索
       </button>
       <button mat-stroked-button (click)="cancelSearchConditions()">
         検索条件クリア
       </button>
-    </div>
+    </mat-card-actions>
   </form>
-</mat-expansion-panel>
+</mat-card>

--- a/src/app/mypage/search-form/search-form.component.html
+++ b/src/app/mypage/search-form/search-form.component.html
@@ -46,22 +46,50 @@
               <mat-label>下限</mat-label>
               <input
                 type="number"
+                step="1"
+                [min]="range.base.min"
+                [max]="range.base.max"
                 matInput
                 autocomplete="off"
                 formControlName="baseLower"
                 class="price"
               />
+              <mat-error
+                *ngIf="
+                  form.get('baseLower').hasError('min') ||
+                  form.get('baseLower').hasError('max') ||
+                  form.get('baseLower').hasError('pattern')
+                "
+              >
+                {{ range.basePerHour.min | number }}から{{
+                  range.basePerHour.max | number
+                }}までの整数を入力してください。
+              </mat-error>
             </mat-form-field>
             〜
             <mat-form-field class="form__field">
               <mat-label>上限</mat-label>
               <input
                 type="number"
+                step="1"
+                [min]="range.base.min"
+                [max]="range.base.max"
                 matInput
                 autocomplete="off"
                 formControlName="baseUpper"
                 class="price"
               />
+              <mat-error
+                *ngIf="
+                  form.get('baseUpper').hasError('min') ||
+                  form.get('baseUpper').hasError('max') ||
+                  form.get('baseUpper').hasError('pattern')
+                "
+              >
+                {{ range.basePerHour.min | number }}から{{
+                  range.basePerHour.max | number
+                }}までの整数を入力してください。
+              </mat-error>
             </mat-form-field>
             <span class="yen">円</span>
           </dd>
@@ -73,22 +101,50 @@
               <mat-label>下限</mat-label>
               <input
                 type="number"
+                step="1"
+                [min]="range.allowance.min"
+                [max]="range.allowance.max"
                 matInput
                 autocomplete="off"
                 formControlName="allowanceLower"
                 class="price"
               />
+              <mat-error
+                *ngIf="
+                  form.get('allowanceLower').hasError('min') ||
+                  form.get('allowanceLower').hasError('max') ||
+                  form.get('allowanceLower').hasError('pattern')
+                "
+              >
+                {{ range.basePerHour.min | number }}から{{
+                  range.basePerHour.max | number
+                }}までの整数を入力してください。
+              </mat-error>
             </mat-form-field>
             〜
             <mat-form-field class="form__field">
               <mat-label>上限</mat-label>
               <input
                 type="number"
+                step="1"
+                [min]="range.allowance.min"
+                [max]="range.allowance.max"
                 matInput
                 autocomplete="off"
                 formControlName="allowanceUpper"
                 class="price"
               />
+              <mat-error
+                *ngIf="
+                  form.get('allowanceUpper').hasError('min') ||
+                  form.get('allowanceUpper').hasError('max') ||
+                  form.get('allowanceUpper').hasError('pattern')
+                "
+              >
+                {{ range.basePerHour.min | number }}から{{
+                  range.basePerHour.max | number
+                }}までの整数を入力してください。
+              </mat-error>
             </mat-form-field>
             <span class="yen">円</span>
           </dd>
@@ -102,22 +158,50 @@
               <mat-label>下限</mat-label>
               <input
                 type="number"
+                step="1"
+                [min]="range.basePerHour.min"
+                [max]="range.basePerHour.max"
                 matInput
                 autocomplete="off"
                 formControlName="basePerHourLower"
                 class="price"
               />
+              <mat-error
+                *ngIf="
+                  form.get('basePerHourLower').hasError('min') ||
+                  form.get('basePerHourLower').hasError('max') ||
+                  form.get('basePerHourLower').hasError('pattern')
+                "
+              >
+                {{ range.basePerHour.min | number }}から{{
+                  range.basePerHour.max | number
+                }}までの整数を入力してください。
+              </mat-error>
             </mat-form-field>
             〜
             <mat-form-field class="form__field">
               <mat-label>上限</mat-label>
               <input
                 type="number"
+                step="1"
+                [min]="range.basePerHour.min"
+                [max]="range.basePerHour.max"
                 matInput
                 autocomplete="off"
                 formControlName="basePerHourUpper"
                 class="price"
               />
+              <mat-error
+                *ngIf="
+                  form.get('basePerHourUpper').hasError('min') ||
+                  form.get('basePerHourUpper').hasError('max') ||
+                  form.get('basePerHourUpper').hasError('pattern')
+                "
+              >
+                {{ range.basePerHour.min | number }}から{{
+                  range.basePerHour.max | number
+                }}までの整数を入力してください。
+              </mat-error>
             </mat-form-field>
             <span class="yen">円</span>
           </dd>

--- a/src/app/mypage/search-form/search-form.component.scss
+++ b/src/app/mypage/search-form/search-form.component.scss
@@ -1,8 +1,26 @@
 @import 'variables';
 @import 'mixins';
 
+mat-card {
+  padding: 16px;
+  @include sm {
+    padding: 24px;
+  }
+}
+mat-card-content {
+  margin: 0;
+  padding: 16px 0;
+}
+mat-card-actions {
+  margin: 0;
+  button {
+    &:first-of-type {
+      color: #fff;
+    }
+  }
+}
+
 .form {
-  padding-top: 16px;
   &__title {
     width: 100%;
     max-width: 300px;
@@ -40,20 +58,6 @@
     font-weight: 400;
     &:not(:last-of-type) {
       margin-right: 21px;
-    }
-  }
-  &__actions {
-    margin-top: 16px;
-    margin-bottom: 8px;
-    button {
-      font-size: 14px;
-      font-weight: 400;
-      &:first-of-type {
-        color: #fff;
-      }
-      &:not(:first-of-type) {
-        margin-left: 8px;
-      }
     }
   }
 }

--- a/src/app/mypage/search-form/search-form.component.ts
+++ b/src/app/mypage/search-form/search-form.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Validators, FormBuilder } from '@angular/forms';
 import { Router, ActivatedRoute, Params } from '@angular/router';
+import { ConditionsService } from 'src/app/services/conditions.service';
 
 @Component({
   selector: 'app-search-form',
@@ -8,22 +9,67 @@ import { Router, ActivatedRoute, Params } from '@angular/router';
   styleUrls: ['./search-form.component.scss'],
 })
 export class SearchFormComponent implements OnInit {
+  readonly range = this.conditionsService.range;
+
   form = this.fb.group({
     title: ['', [Validators.maxLength(20)]],
     typeMonthly: [false, []],
     typeHourly: [false, []],
-    baseLower: [null, [Validators.maxLength(8)]],
-    baseUpper: [null, [Validators.maxLength(8)]],
-    allowanceLower: [null, [Validators.maxLength(8)]],
-    allowanceUpper: [null, [Validators.maxLength(8)]],
-    basePerHourLower: [null, [Validators.maxLength(6)]],
-    basePerHourUpper: [null, [Validators.maxLength(6)]],
+    baseLower: [
+      null,
+      [
+        Validators.min(this.range.base.min),
+        Validators.max(this.range.base.max),
+        Validators.pattern(/^[0-9]\d*$/),
+      ],
+    ],
+    baseUpper: [
+      null,
+      [
+        Validators.min(this.range.base.min),
+        Validators.max(this.range.base.max),
+        Validators.pattern(/^[0-9]\d*$/),
+      ],
+    ],
+    allowanceLower: [
+      null,
+      [
+        Validators.min(this.range.allowance.min),
+        Validators.max(this.range.allowance.max),
+        Validators.pattern(/^[0-9]\d*$/),
+      ],
+    ],
+    allowanceUpper: [
+      null,
+      [
+        Validators.min(this.range.allowance.min),
+        Validators.max(this.range.allowance.max),
+        Validators.pattern(/^[0-9]\d*$/),
+      ],
+    ],
+    basePerHourLower: [
+      null,
+      [
+        Validators.min(this.range.basePerHour.min),
+        Validators.max(this.range.basePerHour.max),
+        Validators.pattern(/^[0-9]\d*$/),
+      ],
+    ],
+    basePerHourUpper: [
+      null,
+      [
+        Validators.min(this.range.basePerHour.min),
+        Validators.max(this.range.basePerHour.max),
+        Validators.pattern(/^[0-9]\d*$/),
+      ],
+    ],
   });
 
   constructor(
     private fb: FormBuilder,
     private router: Router,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private conditionsService: ConditionsService
   ) {}
 
   ngOnInit(): void {}
@@ -61,6 +107,7 @@ export class SearchFormComponent implements OnInit {
         params.allowanceUpper = +formValue.allowanceUpper;
       }
     }
+
     if (formValue.typeHourly) {
       if (formValue.basePerHourLower) {
         params.basePerHourLower = +formValue.basePerHourLower;

--- a/src/app/services/conditions.service.ts
+++ b/src/app/services/conditions.service.ts
@@ -38,7 +38,7 @@ export class ConditionsService {
     },
     basePerHour: {
       min: 0,
-      max: 999999,
+      max: 99999,
     },
     travelCostPerDay: {
       min: 0,


### PR DESCRIPTION
fix #109 
fix #110 
お疲れ様です。
下記の修正を行いました。
ご確認よろしくお願いいたします。

- [x] 条件一覧のblankメッセージ表示
- [x] 検索フォームレイアウトをパネルからカードに修正
- [x]  検索フォームのバリデータを実装
- [x] mypage内のコンポーネント リファクタリング

![image](https://user-images.githubusercontent.com/46749854/96820031-01876b00-1460-11eb-8001-2ee3025f7b55.png)
